### PR TITLE
feat(loan-form): add calculate interaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "lodash.camelcase": "^4.3.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "webpack": "^3.5.5",

--- a/src/loan_form/LoanEntries.jsx
+++ b/src/loan_form/LoanEntries.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import LoanEntry from './loan_entry/LoanEntry'
 
-export default function LoanEntries({ loans }) {
+export default function LoanEntries({ loans, onFieldChange }) {
   return (
-    <div id='loan-entries'>
-      { loans.map((loan, idx) => <LoanEntry key={idx} {...loan} />) }
-    </div>
-  )
+      <div id='loan-entries'>
+        { loans.map((loan, idx) => <LoanEntry key={idx} onFieldChange={onFieldChange} {...loan} />) }
+      </div>
+    )
 }

--- a/src/loan_form/LoanForm.jsx
+++ b/src/loan_form/LoanForm.jsx
@@ -4,14 +4,16 @@ import LoanEntries from './LoanEntries'
 import AddLoan from './buttons/AddLoanButton'
 import Calculate from './buttons/CalculateButton'
 import emptyLoan from '../models/loan/emptyLoan'
+import Calculation from './loan_calculate/Calculation'
+import camelCase from 'lodash.camelcase'
 
-const calculate = e => console.log('calculate')
-
+@autobind
 export default class LoanForm extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      loans: [emptyLoan(0)]
+      loans: [emptyLoan(0)],
+      maxMonthsToPayOffLoan: 0
     }
   }
 
@@ -19,8 +21,7 @@ export default class LoanForm extends React.Component {
     const lastId = this.state.loans[this.state.loans.length - 1].id
     return emptyLoan(lastId + 1)
   }
-
-  @autobind
+  
   handleAddLoan() {
     const newLoans = this.state.loans.concat(
       this.createLoan()
@@ -29,14 +30,68 @@ export default class LoanForm extends React.Component {
     this.setState({ loans: newLoans })
   }
   
+  handleChange(id, name, value) {
+    const newLoans = this.state.loans
+
+    for (var i = 0; i < this.state.loans.length; i++) {
+      if (this.state.loans[i]['id'] == parseInt(id)) {
+        newLoans[i][camelCase(name)] = value
+        newLoans[i].monthsToPayOffLoan = this.findLoanLength(newLoans[i])
+      }
+    }
+
+    this.setState({ loans: newLoans })
+  }
+
+  daysInYear(year) {
+    return 365
+  }
+
+  daysInMonth(month) {
+    return 30.417
+  }
+
+  effectiveMonthlyInterest(amountOwed, yearlyInterestRate, month, year) {
+    return amountOwed * (((1 + yearlyInterestRate / this.daysInYear(year)) ** this.daysInMonth(month)) - 1)
+  }
+
+  findLoanLength({amountOwed, interestRate, monthlyPayment}) {
+    
+    let tempAmountOwed = parseFloat(amountOwed)
+    let interest = this.effectiveMonthlyInterest(tempAmountOwed, interestRate)
+    let monthsToPayOffLoan = 0
+
+    if (monthlyPayment <= interest && amountOwed > 0) {
+      monthsToPayOffLoan = Infinity
+    } else {
+      while (tempAmountOwed > 0) {
+        monthsToPayOffLoan += 1
+        interest = this.effectiveMonthlyInterest(tempAmountOwed, interestRate)
+        tempAmountOwed += interest - monthlyPayment
+      }
+    }
+
+    return monthsToPayOffLoan
+  }
+
+  calculate() {
+    const max = (x, y) => (x > y ? x : y)
+    const maxMonthsToPayOffLoan = this.state.loans
+      .map(loan => loan.monthsToPayOffLoan)
+      .reduce(max)
+
+    this.setState({ maxMonthsToPayOffLoan: maxMonthsToPayOffLoan })
+  }
+  
   render() {
     return (
       <div>
-        <LoanEntries loans={this.state.loans} />
+        <LoanEntries loans={this.state.loans} onFieldChange={this.handleChange}/>
         <div>
           <AddLoan onClick={this.handleAddLoan} />
-          <Calculate onClick={calculate}/>
+          <Calculate onClick={this.calculate}/>
         </div>
+        <Calculation total_months={this.state.maxMonthsToPayOffLoan} />
       </div>
     )
   }

--- a/src/loan_form/loan_calculate/Calculation.jsx
+++ b/src/loan_form/loan_calculate/Calculation.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Calculation({ total_months }) {
+  return (
+    <div>
+      <p>It will take {total_months === Infinity ? 'literally forever' : `${total_months} month${total_months === 1 ? '' : 's'}` } to pay off your loans.</p>
+    </div>
+  )
+}

--- a/src/loan_form/loan_entry/LoanEntry.jsx
+++ b/src/loan_form/loan_entry/LoanEntry.jsx
@@ -1,18 +1,16 @@
 import React from 'react'
+import autobind from 'autobind-decorator'
 import LoanEntryField from './LoanEntryField'
 import RemoveLoan from '../buttons/RemoveLoanButton'
 
 export default class LoanEntry extends React.Component {
   constructor (props) {
     super(props)
-    this.state = this.props
-    this.handleChange = this.handleChange.bind(this)
   }
 
-  handleChange(event) {
-    this.setState({
-      [event.target.name]: event.target.value
-    })
+  @autobind
+  handleChange({ target: { id, name, value } }) {
+    this.props.onFieldChange(id, name, value)
   }
 
   render() {
@@ -50,7 +48,7 @@ export default class LoanEntry extends React.Component {
           field_id={interestRateFieldId}
           name={interestRateFieldName}
           value={interestRateFieldValue}
-          label={'Interest Rate:'}
+          label={'Yearly Interest Rate (Decimal):'}
           on_change={this.handleChange} />
         <LoanEntryField
           field_id={monthlyPaymentFieldId}

--- a/src/models/loan/emptyLoan.js
+++ b/src/models/loan/emptyLoan.js
@@ -4,6 +4,7 @@ const emptyLoan = id => ({
   amountOwed: 0,
   interestRate: 0,
   monthlyPayment: 0,
+  monthsToPayOffLoan: 0
 })
 
 export default emptyLoan

--- a/yarn.lock
+++ b/yarn.lock
@@ -2087,6 +2087,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
 lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -2205,17 +2209,7 @@ miller-rabin@^4.0.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-db@~1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
-
-mime-types@^2.1.12, mime-types@~2.1.7:
-  version "2.1.16"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
-  dependencies:
-    mime-db "~1.29.0"
-
-mime-types@~2.1.15, mime-types@~2.1.16:
+mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:


### PR DESCRIPTION
**Loan Entry Model:** Now has a key & value for the total months it would take to pay off the loan, calculated whenever the state changes on amount owed, interest, or monthly payment
**Loan Entry:** Lifted the state up from individual entries all the way up to the loan-form so we can calculate the total number of months required
**Calculation:** Now there's a thing to display the calculation, more on math below
**Loan Form:** Three new functions, handleChange, findLoanLength & calculate. The first manages state for every field regardless of how many there are (in theory). The second calculates the total number of months needed to pay off an _individual_ loan and is called whenever relevant states change. The third returns the largest of the loan lengths.
**Loan Entries:** Now this component is a class, along with a few others (woo)