### PR TITLE
feat(loan-form): add monthly payment calculation

### DIFF
--- a/src/loan_form/LoanForm.jsx
+++ b/src/loan_form/LoanForm.jsx
@@ -16,9 +16,8 @@ import Ledger, {
 } from '../models/ledger'
 import { loanAt } from '../models/ledger/lenses'
 import { loanProp, repaymentTerm as loanRepaymentTerm } from '../models/loan/lenses'
-import emptyLoan from '../models/loan/emptyLoan'
+import { emptyLoan, calculateRepaymentTerm } from '../models/loan'
 import FREQUENCY from '../models/frequency/frequencyEnum'
-
 
 @autobind
 export default class LoanForm extends React.Component {
@@ -39,77 +38,15 @@ export default class LoanForm extends React.Component {
   }
 
   handleChange(id, name, value) {
-<<<<<<< HEAD
-    const newLoans = this.state.loans
-
-    for (var i = 0; i < this.state.loans.length; i++) {
-      if (this.state.loans[i]['id'] == parseInt(id)) {
-        switch(name) {
-          case 'title':
-            newLoans[i]['debt'][camelCase(name)] = value
-            break
-          case 'amount-owed':
-            newLoans[i]['debt'][camelCase(name)] = value ? parseFloat(value) : 0
-            break
-          case 'rate':
-            newLoans[i]['debt']['interestRate'][camelCase(name)] = value ? parseFloat(value) : 0
-            break
-          case 'monthly-payment':
-            newLoans[i]['paymentPlan'][camelCase(name)] = value ? parseFloat(value) : 0
-            break
-        }
-        newLoans[i].paymentPlan.repaymentTerm = this.calculateRepaymentTerm(newLoans[i])
-      }
-    }
-=======
     const changedLoanProperty = R.compose(loanAt(id), loanProp(camelCase(name)))
     const steps = [
       R.set(changedLoanProperty, value),
       R.over(loanAt(parseInt(id)),
-             loan => R.set(loanRepaymentTerm, this.calculateRepaymentTerm(loan), loan))
+             loan => R.set(loanRepaymentTerm, calculateRepaymentTerm(loan), loan))
     ]
->>>>>>> develop
 
     const newLedger = R.reduce(R.flip(R.call), this.state.ledger, steps)
     this.setState({ ledger: newLedger })
-  }
-
-  daysInYear(year) {
-    return 365
-  }
-
-  daysInMonth(month) {
-    return 30.417
-  }
-
-  effectiveMonthlyInterestRate(yearlyInterestRate, month, year) {
-    return ((1 + yearlyInterestRate / this.daysInYear(year)) ** this.daysInMonth(month)) - 1
-  }
-
-  calculateRepaymentTerm({debt:{amountOwed, interestRate: {rate}}, paymentPlan: {monthlyPayment}}) {
-<<<<<<< HEAD
-    const a = Math.log(monthlyPayment),
-          b = Math.log(monthlyPayment - amountOwed * this.effectiveMonthlyInterestRate(rate)),
-          c = Math.log(1 + this.effectiveMonthlyInterestRate(rate))
-    
-    const repaymentTerm = rate ? (a - b) / c : amountOwed / monthlyPayment
-
-    return Math.ceil(repaymentTerm)
-  }
-=======
-    let tempAmountOwed = parseFloat(amountOwed)
-    let interest = this.effectiveMonthlyInterest(tempAmountOwed, rate)
-    let repaymentTerm = 0
->>>>>>> develop
-
-  calculateMonthlyPayment({debt:{amountOwed, interestRate: {rate}}, paymentPlan: {repaymentTerm}}) {
-    const interestRate = this.effectiveMonthlyInterestRate(rate)
-    if (rate) {
-      const monthlyPayment = amountOwed * (interestRate / (1 - (1 + interestRate) ** -repaymentTerm))
-    } else {
-      const monthlyPayment = amountOwed / repaymentTerm
-    }
-    return monthlyPayment
   }
 
   calculate() {

--- a/src/models/ledger/__tests__/repaymentTermTest.js
+++ b/src/models/ledger/__tests__/repaymentTermTest.js
@@ -13,4 +13,13 @@ describe('#repaymentTerm', () => {
   it('should calculate the repayment term for the entire ledger', () => {
     expect(repaymentTerm(ledger)).toEqual(expectedRepaymentTerm)
   })
+
+  const loan4 = { paymentPlan: { repaymentTerm: 100 } }
+  const loan5 = { paymentPlan: { repaymentTerm: Infinity } }
+  const ledger2 = Ledger.withLoans([loan4, loan5])
+  const expectedRepaymentTerm2 = Infinity
+
+  it('should calculate a repayment term of Infinity when one loan is unpayable', () => {
+    expect(repaymentTerm(ledger2)).toEqual(expectedRepaymentTerm2)
+  })
 })

--- a/src/models/loan/__tests__/paymentCalculationsTest.js
+++ b/src/models/loan/__tests__/paymentCalculationsTest.js
@@ -1,0 +1,75 @@
+import { calculateRepaymentTerm, calculateMonthlyPayment } from '../paymentCalculations'
+import defaultDebt from '../../debt/defaultDebt'
+import defaultPaymentPlan from '../../payment_plan/defaultPaymentPlan'
+import emptyLoan from '../emptyLoan'
+
+jest.disableAutomock()
+
+var loans = Array.apply(null, Array(6)).map(() => emptyLoan())
+
+loans[0].debt.amountOwed = 0
+loans[0].debt.interestRate.rate = 10000
+loans[0].paymentPlan.monthlyPayment = 0
+loans[0].paymentPlan.repaymentTerm = 0
+
+loans[1].debt.amountOwed = 100
+loans[1].debt.interestRate.rate = 0
+loans[1].paymentPlan.monthlyPayment = 10
+loans[1].paymentPlan.repaymentTerm = 10
+
+loans[2].debt.amountOwed = 100
+loans[2].debt.interestRate.rate = .001
+loans[2].paymentPlan.monthlyPayment = 10
+loans[2].paymentPlan.repaymentTerm = 11
+
+loans[3].debt.amountOwed = 1000
+loans[3].debt.interestRate.rate = .05
+loans[3].paymentPlan.monthlyPayment = 80
+loans[3].paymentPlan.repaymentTerm = 13
+
+loans[4].debt.amountOwed = 100
+loans[4].debt.interestRate.rate = 1
+loans[4].paymentPlan.monthlyPayment = 8.67
+loans[4].paymentPlan.repaymentTerm = Infinity
+
+loans[5].debt.amountOwed = 100
+loans[5].debt.interestRate.rate = 1
+loans[5].paymentPlan.monthlyPayment = 8.68
+loans[5].paymentPlan.repaymentTerm = 102
+
+describe('#calculateRepaymentTerm', () => {
+
+  it('should calculate an infinite repayment term when the amount owed is more than 0 and the monthly interest is greater than the monthly repayment', () => {
+    expect(calculateRepaymentTerm(loans[4])).toEqual(Infinity)
+  })
+
+  it('should just divide the amount owed by the monthly payment if there\'s no interest rate', () => {
+    expect(calculateRepaymentTerm(loans[1])).toEqual(10)
+  })
+
+  it('should return an accurate estimate of the number of months required to pay otherwise', () => {
+    expect(calculateRepaymentTerm(loans[0])).toEqual(0)
+    expect(calculateRepaymentTerm(loans[2])).toEqual(11)
+    expect(calculateRepaymentTerm(loans[3])).toBeGreaterThan(10)
+    expect(calculateRepaymentTerm(loans[3])).toBeLessThan(15)
+    expect(calculateRepaymentTerm(loans[5])).toBeGreaterThan(100)
+    expect(calculateRepaymentTerm(loans[5])).toBeLessThan(105)
+  })
+})
+
+describe('#calculateMonthlyPayment', () => {
+
+  it('should just divide the amount owed by the monthly payment if there\'s no interest rate', () => {
+    expect(calculateMonthlyPayment(loans[1])).toEqual(10)
+  })
+
+  it('should return an accurate estimate of the number of months required to pay otherwise', () => {
+    expect(calculateMonthlyPayment(loans[0])).toEqual(0)
+    expect(calculateMonthlyPayment(loans[2])).toBeGreaterThan(9)
+    expect(calculateMonthlyPayment(loans[2])).toBeLessThan(11)
+    expect(calculateMonthlyPayment(loans[3])).toBeGreaterThan(70)
+    expect(calculateMonthlyPayment(loans[3])).toBeLessThan(90)
+    expect(calculateMonthlyPayment(loans[5])).toBeGreaterThan(8.6)
+    expect(calculateMonthlyPayment(loans[5])).toBeLessThan(8.68)
+  })
+})

--- a/src/models/loan/index.js
+++ b/src/models/loan/index.js
@@ -1,7 +1,9 @@
 import _emptyLoan from './emptyLoan'
 import _updateLoanAttribute from './updateLoanAttribute'
 import _updateLoanAttributeWith from './updateLoanAttributeWith'
+import { calculateRepaymentTerm, calculateMonthlyPayment } from './paymentCalculations'
 
 export const emptyLoan = _emptyLoan
 export const updateLoanAttribute = _updateLoanAttribute
 export const updateLoanAttributeWith = _updateLoanAttributeWith
+export { calculateRepaymentTerm, calculateMonthlyPayment }

--- a/src/models/loan/paymentCalculations.js
+++ b/src/models/loan/paymentCalculations.js
@@ -1,0 +1,43 @@
+function daysInYear(year) {
+  return 365
+}
+
+function daysInMonth(month) {
+  return 30.417
+}
+
+function effectiveMonthlyInterestRate(yearlyInterestRate, month, year) {
+  return ((1 + yearlyInterestRate / daysInYear(year)) ** daysInMonth(month)) - 1
+}
+
+const calculateRepaymentTerm = ({debt:{amountOwed, interestRate: {rate}}, paymentPlan: {monthlyPayment}}) => {
+  if (amountOwed == 0 ) {
+    return 0
+  } else if (rate) {
+    const interestRate = effectiveMonthlyInterestRate(rate)
+    if (monthlyPayment <= amountOwed * interestRate && amountOwed > 0) {
+      return Infinity
+    } else {
+      return Math.ceil(
+        (Math.log(monthlyPayment)
+          - Math.log(monthlyPayment - amountOwed * interestRate)
+        ) / Math.log(1 + interestRate)
+      )
+    }
+  } else {
+    return Math.ceil(amountOwed / monthlyPayment)
+  }
+}
+
+const calculateMonthlyPayment = ({debt:{amountOwed, interestRate: {rate}}, paymentPlan: {repaymentTerm}}) => {
+  if (amountOwed == 0) {
+    return 0
+  } else if (rate) {
+    const interestRate = effectiveMonthlyInterestRate(rate)
+    return amountOwed * (interestRate / (1 - (1 + interestRate) ** -repaymentTerm))
+  } else {
+    return amountOwed / repaymentTerm
+  }
+}
+
+export { calculateRepaymentTerm, calculateMonthlyPayment }


### PR DESCRIPTION
Added `calculateMonthlyPayment`, and refactored `calculateRepaymentTerm` to use the same basic equation as `calculateMonthlyPayment`. Also started `parseFloat`-ing the input values for the fields where we anticipate numbers, as I was having some `NaN` troubles.

Minor refactor: changed the effective monthly interest function to an effective monthly interest _rate_ function so that i'd be able to use it in both calculators. Also now we officially account for cases where the interest rate is 0